### PR TITLE
Bumps version of node-hid.

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "test": "mocha"
   },
   "dependencies": {
-    "node-hid": "^0.3.2",
+    "node-hid": "^0.5.4",
     "async": "",
     "psl": "",
     "request": ""


### PR DESCRIPTION
This is an attempt to fix #3.  Note: I have not tested this locally (hoping you have a CI server for that) and I don't actually know if it will fix the issue, but it seems like a good place to start as 0.3.2 was from 2.5 years ago.